### PR TITLE
preserve enclosing [] to ensure ipv6 lit hostname remains valid

### DIFF
--- a/src/webmachine_dispatcher.erl
+++ b/src/webmachine_dispatcher.erl
@@ -66,12 +66,15 @@ split_host_port(HostAsString, Scheme) ->
     end.
 
 split_host_port0("[" ++ _Rest = HostAsString) ->
-    case string:tokens(HostAsString, "[]") of
+    {Host, Port} = case string:tokens(HostAsString, "[]") of
         [HostPart, ":" ++ PortPart] ->
             {HostPart, PortPart};
         [HostPart] ->
             {HostPart, no_port}
-    end;
+    end,
+    % Preserve the enclosing [ ], to ensure that that the ipv6
+    % literal remains valid as a host value.
+    {"[" ++ Host ++ "]", Port};
 split_host_port0(HostAsString) ->
     case string:tokens(HostAsString, ":") of
         [HostPart, PortPart] ->


### PR DESCRIPTION
In the case where hostname arrives as a bracketed ipv6 literal,
we don't split into separate parts based on '.' as that's not valid
within an ipv6 address. In these cases, this change lets us preserve
the address in a way that clients can use directly, without having to
check for ipv6/ipv4/hostname formatting.

@seth @manderson26 @hosh 
