### PR TITLE
Update crypto md5 to erlang:md5 to support FIPS

### DIFF
--- a/src/webmachine_decision_core.erl
+++ b/src/webmachine_decision_core.erl
@@ -737,7 +737,7 @@ variances() ->
 
 -ifndef(old_hash).
 md5(Bin) ->
-    crypto:hash(md5, Bin).
+    erlang:md5(Bin).
 
 md5_init() ->
     crypto:hash_init(md5).

--- a/test/decision_core_test.erl
+++ b/test/decision_core_test.erl
@@ -29,7 +29,7 @@
 
 -ifndef(old_hash).
 md5(Bin) ->
-    crypto:hash(md5,Bin).
+    erlang:md5(Bin).
 -else.
 md5(Bin) ->
     crypto:md5(Bin).


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

crypto:md5 in not supported in FIPS mode and causes errors.
Replace it with erlang:md5
This will let us use crypto from erlang instead of the patch that is currently used in chef-server

Will help solve: https://github.com/chef/chef-server/issues/1877

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
